### PR TITLE
Update rubygems on travis-ci.org to make REE with Rails 3.2 happy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - rbx-18mode
   - rbx-19mode
   - ree
+before_install:
+  - gem update --system
+  - gem --version # make sure rubygems actually were updated
 before_script:
   - "psql -U postgres -c 'create database tree_test;'"
 script: bundle exec rake test


### PR DESCRIPTION
REE ships with an old rubygems version that Rails 3.2 does not work with.
